### PR TITLE
docker: add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pihole6_exporter /app/pihole6_exporter
+
+RUN pip install --no-cache-dir requests prometheus_client urllib3
+
+CMD ["python3", "pihole6_exporter"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is a basic prometheus exporter for the new API in Pi-hole version 6, curren
 
 [There is a Grafana Dashboard as well!](https://grafana.com/grafana/dashboards/21043-pi-hole-ver6-stats/)
 
+[Docker Image](https://hub.docker.com/r/totaltax/pihole6_exporter)
+
 **UPDATE:** Also included here (see below) is a query logger meant to run as a systemd timer every minute.  It generates digestible logs out of the API's `/queries` call!
 
 ## pihole6_exporter
@@ -11,15 +13,7 @@ This is a basic prometheus exporter for the new API in Pi-hole version 6, curren
 ### Running
 
 ```
-usage: pihole6_exporter [-h] [-H HOST] [-p PORT] [-k KEY]
-
-Prometheus exporter for Pi-hole version 6+
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -H HOST, --host HOST  hostname/ip of pihole instance (default localhost)
-  -p PORT, --port PORT  port to expose for scraping (default 9666)
-  -k KEY, --key KEY     authentication token
+$ HOST=[pihole_ip] KEY=[your_api_key] PORT=[port] pihole6_exporter
 ```
 
 If using locally and you have the `Local clients need to authenticate to access the API` option un-selected, a key is not necessary.  This key is the "app password", not the session ID that is created with it.
@@ -35,7 +29,7 @@ The session ID should stay active as long as it is used at least every 5 minutes
 
 * Copy the exporter itself over to `/usr/local/bin`
 * Copy the systemd service file over to `/etc/systemd/system/` (or anywhere systemd will find it)
-    * Modify the `Exec=` line with any command line args (like a key) as needed.  Currently there is no config file.  
+    * Modify the `Enviroment=` lines as needed.  Currently there is no config file.  
 * `systemctl start pihole6-exporter` to start the exporter.
 * `systemctl enable pihole6-exporter` to have it start automatically.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,19 @@ This is a basic prometheus exporter for the new API in Pi-hole version 6, curren
 ### Running
 
 ```
-$ HOST=[pihole_ip] KEY=[your_api_key] PORT=[port] pihole6_exporter
+$ PIHOLE_HOST=localhost PIHOLE_PORT=443 PIHOLE_PROTOCOL=https EXPORTER_PORT=9666 KEY="" pihole6_exporter
+```
+### Via docker
+```
+docker run -d \ 
+  --name pihole6_exporter \
+  -p 9666:9666 \
+  -e EXPORTER_PORT=9666 # These are all default values
+  -e PIHOLE_PROTOCOL="https" \
+  -e PIHOLE_PORT=443 \ 
+  -e PIHOLE_HOST="localhost" \ 
+  -e KEY="" \ # Leave blank for no auth
+  totaltax/pihole6_exporter:latest
 ```
 
 If using locally and you have the `Local clients need to authenticate to access the API` option un-selected, a key is not necessary.  This key is the "app password", not the session ID that is created with it.

--- a/pihole6_exporter
+++ b/pihole6_exporter
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
 
+import os
 import time
 import requests
 import urllib3
-import argparse
 import logging
 from datetime import datetime
 from prometheus_client.core import GaugeMetricFamily, REGISTRY
 from prometheus_client import start_http_server
 
+HOST = os.getenv("PIHOLE_HOST", "localhost")
+PORT = int(os.getenv("PORT", "9666"))
+KEY  = os.getenv("PIHOLE_KEY", None)
 
 class PiholeCollector(object):
-
-
     def __init__(self, host="localhost", key=None):
 
         self.using_auth = False
@@ -244,21 +245,10 @@ class PiholeCollector(object):
         
 
 if __name__ == '__main__':
-    
-    logging.basicConfig(format='level="%(levelname)s" message="%(message)s"', level=logging.INFO)
-
-    parser = argparse.ArgumentParser(description="Prometheus exporter for Pi-hole version 6+")
-
-    parser.add_argument("-H", "--host", dest="host", type=str, required=False, help="hostname/ip of pihole instance (default localhost)", default="localhost")
-    parser.add_argument("-p", "--port", dest="port", type=int, required=False, help="port to expose for scraping (default 9666)", default=9666)
-    parser.add_argument("-k", "--key", dest="key", type=str, required=False, help="authentication token (if required)", default=None)
-
-    args = parser.parse_args()
-
-    start_http_server(args.port)
+    start_http_server(PORT)
     logging.info("Exporter HTTP endpoint started")
 
-    REGISTRY.register(PiholeCollector(args.host, args.key))
+    REGISTRY.register(PiholeCollector(HOST, KEY))
     logging.info("Ready to collect data")
     while True:
         time.sleep(1)

--- a/pihole6_exporter
+++ b/pihole6_exporter
@@ -9,18 +9,19 @@ from datetime import datetime
 from prometheus_client.core import GaugeMetricFamily, REGISTRY
 from prometheus_client import start_http_server
 
-HOST = os.getenv("PIHOLE_HOST", "localhost")
-PORT = int(os.getenv("PORT", "9666"))
-KEY  = os.getenv("PIHOLE_KEY", None)
+PIHOLE_HOST = os.getenv("PIHOLE_HOST", "localhost")
+PIHOLE_PORT = os.getenv("PIHOLE_PORT", "443")
+PIHOLE_PROTOCOL = os.getenv("PIHOLE_PROTOCOL", "https")
+EXPORTER_PORT = int(os.getenv("EXPORTER_PORT", "9666"))
+KEY = os.getenv("KEY", None)
 
 class PiholeCollector(object):
-    def __init__(self, host="localhost", key=None):
+    def __init__(self, protocol, host, port, key):
 
         self.using_auth = False
         # Disable if you've actually got a good cert set up.
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
-        self.host = host
+        self.base_url = f"{protocol}://{host}:{port}"
 
         if key is not None:
             self.using_auth = True
@@ -34,7 +35,7 @@ class PiholeCollector(object):
 
 
     def get_sid(self, key):
-        auth_url = "https://" + self.host + ":443/api/auth"
+        auth_url = f"{self.base_url}/api/auth"
         headers = {"accept": "application/json", "content_type": "application/json"}
         json_data = {"password": key}
         req = requests.post(auth_url, verify = False, headers = headers, json = json_data)
@@ -44,13 +45,12 @@ class PiholeCollector(object):
 
 
     def get_api_call(self, api_path):
-        url = "https://" + self.host + ":443/api/" + api_path
+        url = f"{self.base_url}/api/{api_path}"
         if self.using_auth:
             headers = {"accept": "application/json", "sid": self.sid}
         else:
             headers = {"accept": "application/json"}
         req = requests.get(url, verify = False, headers = headers)
-        
         return req.json()
 
 
@@ -245,10 +245,10 @@ class PiholeCollector(object):
         
 
 if __name__ == '__main__':
-    start_http_server(PORT)
+    start_http_server(EXPORTER_PORT)
     logging.info("Exporter HTTP endpoint started")
 
-    REGISTRY.register(PiholeCollector(HOST, KEY))
+    REGISTRY.register(PiholeCollector(PIHOLE_PROTOCOL, PIHOLE_HOST, PIHOLE_PORT, KEY))
     logging.info("Ready to collect data")
     while True:
         time.sleep(1)

--- a/pihole6_exporter.service
+++ b/pihole6_exporter.service
@@ -3,9 +3,11 @@ Description=Pihole 6 Prometheus Exporter
 After=pihole-FTL.service
 
 [Service]
-Environment="KEY="
-Environment="HOST=localhost"
-Environment="PORT=9666"
+Environment="PIHOLE_PROTOCOL=https"
+Environment="PIHOLE_HOST=localhost"
+Environment="PIHOLE_PORT=443"
+Environment="EXPORTER_PORT=9666"
+Environment="KEY=''"
 ExecStart=/usr/local/bin/pihole6_exporter
 Type=exec
 Restart=always

--- a/pihole6_exporter.service
+++ b/pihole6_exporter.service
@@ -3,6 +3,9 @@ Description=Pihole 6 Prometheus Exporter
 After=pihole-FTL.service
 
 [Service]
+Environment="KEY="
+Environment="HOST=localhost"
+Environment="PORT=9666"
 ExecStart=/usr/local/bin/pihole6_exporter
 Type=exec
 Restart=always


### PR DESCRIPTION
This pr adds a Dockerfile to the repo so that it can be deployed via docker. Right now it is only the exporter and I did not include the logger. I did remove the command line args in favor of environment variables for easier use via docker but I it is possible to do some kind of hybrid if you still want them. I also added:
- PIHOLE_PORT: Change pihole port
- PIHOLE_PROTOCOL: Change protocol (http/https)

close: #1 